### PR TITLE
Add auth

### DIFF
--- a/apis/profile/README.md
+++ b/apis/profile/README.md
@@ -1,0 +1,9 @@
+# Profile API
+
+- Create a `.env` file in the root directory with the following content
+
+```sh
+PORT='replace with port number'
+AUTH0_AUDIENCE='replace with audience from Auth0 dashboard'
+AUTH0_ISSUER_BASE_URL='replace with domain from Auth0 dashboard'
+```

--- a/apis/profile/package.json
+++ b/apis/profile/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "PORT=4000 nodemon src/index.ts"
+    "dev": "nodemon src/index.ts"
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-oauth2-jwt-bearer": "^1.6.0"
   },

--- a/apis/profile/package.json
+++ b/apis/profile/package.json
@@ -7,7 +7,8 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-oauth2-jwt-bearer": "^1.6.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.3",

--- a/apis/profile/src/index.ts
+++ b/apis/profile/src/index.ts
@@ -1,5 +1,15 @@
 import express from "express";
 import cors from "cors";
+import { auth, requiredScopes } from "express-oauth2-jwt-bearer";
+
+// Authorization middleware. When used, the Access Token must
+// exist and be verified against the Auth0 JSON Web Key Set.
+const checkJwt = auth({
+  audience: "http://localhost:4000",
+  issuerBaseURL: `https://dev-qxah68iucyxmju34.us.auth0.com/`,
+});
+
+const checkScopes = requiredScopes("read:profile");
 
 const app = express();
 
@@ -7,7 +17,9 @@ const port = process.env.PORT || 4002;
 
 app.use(cors({ origin: "*" }));
 
-app.get("/profile", (_, res) => {
+const checks = [checkJwt, checkScopes];
+
+app.get("/profile", ...checks, (_, res) => {
   res
     .status(200)
     .send({ name: "Hippo Fan", address: "123 Hippopotimus Boulevard" });

--- a/apis/profile/src/index.ts
+++ b/apis/profile/src/index.ts
@@ -10,7 +10,7 @@ const checkJwt = auth({
   tokenSigningAlg: "RS256",
 });
 
-const checkScopes = requiredScopes("read:profile");
+const checkScopes = requiredScopes("read:all_data");
 
 const app = express();
 

--- a/apis/profile/src/index.ts
+++ b/apis/profile/src/index.ts
@@ -1,12 +1,15 @@
 import express from "express";
 import cors from "cors";
 import { auth, requiredScopes } from "express-oauth2-jwt-bearer";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 // Authorization middleware. When used, the Access Token must
 // exist and be verified against the Auth0 JSON Web Key Set.
 const checkJwt = auth({
-  audience: "http://localhost:4000",
-  issuerBaseURL: `https://dev-qxah68iucyxmju34.us.auth0.com/`,
+  audience: process.env.AUTH0_AUDIENCE,
+  issuerBaseURL: process.env.AUTH0_ISSUER_BASE_URL,
   tokenSigningAlg: "RS256",
 });
 

--- a/apis/profile/src/index.ts
+++ b/apis/profile/src/index.ts
@@ -7,6 +7,7 @@ import { auth, requiredScopes } from "express-oauth2-jwt-bearer";
 const checkJwt = auth({
   audience: "http://localhost:4000",
   issuerBaseURL: `https://dev-qxah68iucyxmju34.us.auth0.com/`,
+  tokenSigningAlg: "RS256",
 });
 
 const checkScopes = requiredScopes("read:profile");

--- a/apps/rwa/README.md
+++ b/apps/rwa/README.md
@@ -1,6 +1,17 @@
 ## Getting Started
 
-First, run the development server:
+First, create a `.env.local` file in the root directory with the following content
+
+```sh
+AUTH0_SECRET='use [openssl rand -hex 32] to generate a 32 bytes value'
+AUTH0_BASE_URL='replace with URL for this app'
+AUTH0_AUDIENCE='replace with audience from Auth0 dashboard'
+AUTH0_ISSUER_BASE_URL='replace with domain from Auth0 dashboard'
+AUTH0_CLIENT_ID='replace with app client id from Auth0 dashboard'
+AUTH0_CLIENT_SECRET='replace with app secret from Auth0 dashboard'
+```
+
+Then run the development server:
 
 ```bash
 yarn dev

--- a/apps/rwa/README.md
+++ b/apps/rwa/README.md
@@ -5,7 +5,7 @@ First, create a `.env.local` file in the root directory with the following conte
 ```sh
 AUTH0_SECRET='use [openssl rand -hex 32] to generate a 32 bytes value'
 AUTH0_BASE_URL='replace with URL for this app'
-AUTH0_AUDIENCE='replace with audience from Auth0 dashboard'
+AUTH0_AUDIENCE='replace with Profile API audience from Auth0 dashboard'
 AUTH0_ISSUER_BASE_URL='replace with domain from Auth0 dashboard'
 AUTH0_CLIENT_ID='replace with app client id from Auth0 dashboard'
 AUTH0_CLIENT_SECRET='replace with app secret from Auth0 dashboard'

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -6,7 +6,7 @@ export const GET = handleAuth({
   login: handleLogin({
     authorizationParams: {
       audience: "http://localhost:4000",
-      scope: "openid read:profile",
+      scope: "openid profile read:profile",
     },
   }),
   signup: handleLogin({ authorizationParams: { screen_hint: "signup" } }),

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -6,7 +6,7 @@ export const GET = handleAuth({
   login: handleLogin({
     authorizationParams: {
       audience: "http://localhost:4000",
-      scope: "openid profile read:profile",
+      scope: "openid profile read:all_data",
     },
   }),
   signup: handleLogin({ authorizationParams: { screen_hint: "signup" } }),

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -1,7 +1,7 @@
 import type { HandleAuth } from "@auth0/nextjs-auth0";
 import { handleAuth, handleLogin } from "@auth0/nextjs-auth0";
 
-// For some reason the inferred type of handleAuth is any
+// For some reason the inferred type of handleAuth is any so casting to HandleAuth
 export const GET = handleAuth({
   login: handleLogin({
     authorizationParams: {

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -1,0 +1,5 @@
+import type { HandleAuth } from "@auth0/nextjs-auth0";
+import { handleAuth } from "@auth0/nextjs-auth0";
+
+// For some reason the inferred type of handleAuth is any
+export const GET = handleAuth() as HandleAuth;

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -3,5 +3,11 @@ import { handleAuth, handleLogin } from "@auth0/nextjs-auth0";
 
 // For some reason the inferred type of handleAuth is any
 export const GET = handleAuth({
+  login: handleLogin({
+    authorizationParams: {
+      audience: "http://localhost:4000",
+      scope: "openid read:profile",
+    },
+  }),
   signup: handleLogin({ authorizationParams: { screen_hint: "signup" } }),
 }) as HandleAuth;

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -5,7 +5,6 @@ import { handleAuth, handleLogin } from "@auth0/nextjs-auth0";
 export const GET = handleAuth({
   login: handleLogin({
     authorizationParams: {
-      audience: "http://localhost:4000",
       scope: "openid profile read:all_data",
     },
   }),

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -1,5 +1,7 @@
 import type { HandleAuth } from "@auth0/nextjs-auth0";
-import { handleAuth } from "@auth0/nextjs-auth0";
+import { handleAuth, handleLogin } from "@auth0/nextjs-auth0";
 
 // For some reason the inferred type of handleAuth is any
-export const GET = handleAuth() as HandleAuth;
+export const GET = handleAuth({
+  signup: handleLogin({ authorizationParams: { screen_hint: "signup" } }),
+}) as HandleAuth;

--- a/apps/rwa/app/api/auth/[auth0]/route.ts
+++ b/apps/rwa/app/api/auth/[auth0]/route.ts
@@ -5,7 +5,7 @@ import { handleAuth, handleLogin } from "@auth0/nextjs-auth0";
 export const GET = handleAuth({
   login: handleLogin({
     authorizationParams: {
-      scope: "openid profile read:all_data",
+      scope: "openid profile read:all_data offline_access",
     },
   }),
   signup: handleLogin({ authorizationParams: { screen_hint: "signup" } }),

--- a/apps/rwa/app/api/profile/route.ts
+++ b/apps/rwa/app/api/profile/route.ts
@@ -1,18 +1,26 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { withApiAuthRequired, getAccessToken } from "@auth0/nextjs-auth0";
 import type { Profile } from "profile-service";
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { getProfile as getProfile_ } from "profile-service";
 
 export const GET = withApiAuthRequired(
-  async (): Promise<NextResponse<Profile>> => {
-    const data = await getProfile_();
+  async (): Promise<NextResponse<Profile | undefined>> => {
+    const { accessToken } = await getAccessToken();
+
+    if (!accessToken) return NextResponse.json(undefined);
+
+    const data = await getProfile_({ accessToken });
 
     return NextResponse.json(data);
   },
 );
 
+// The front end calls this function, which then calls the GET endpoint
 export const getProfile = async (): Promise<Profile> => {
-  const response = await fetch("http://localhost:3000/api/profile");
+  const response = await fetch("http://localhost:3000/api/profile", {
+    headers: { Cookie: cookies().toString() },
+  });
 
   const data = (await response.json()) as Profile;
 

--- a/apps/rwa/app/api/profile/route.ts
+++ b/apps/rwa/app/api/profile/route.ts
@@ -1,12 +1,15 @@
+import { withApiAuthRequired } from "@auth0/nextjs-auth0";
 import type { Profile } from "profile-service";
 import { NextResponse } from "next/server";
 import { getProfile as getProfile_ } from "profile-service";
 
-export const GET = async (): Promise<NextResponse<Profile>> => {
-  const data = await getProfile_();
+export const GET = withApiAuthRequired(
+  async (): Promise<NextResponse<Profile>> => {
+    const data = await getProfile_();
 
-  return NextResponse.json(data);
-};
+    return NextResponse.json(data);
+  },
+);
 
 export const getProfile = async (): Promise<Profile> => {
   const response = await fetch("http://localhost:3000/api/profile");

--- a/apps/rwa/app/api/profile/route.ts
+++ b/apps/rwa/app/api/profile/route.ts
@@ -4,11 +4,15 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getProfile as getProfile_ } from "profile-service";
 
+interface ErrorResponse {
+  status: number;
+}
+
 export const GET = withApiAuthRequired(
-  async (): Promise<NextResponse<Profile | undefined>> => {
+  async (): Promise<NextResponse<Profile | ErrorResponse>> => {
     const { accessToken } = await getAccessToken();
 
-    if (!accessToken) return NextResponse.json(undefined);
+    if (!accessToken) return NextResponse.json({ status: 401 });
 
     const data = await getProfile_({ accessToken });
 

--- a/apps/rwa/app/api/profile/route.ts
+++ b/apps/rwa/app/api/profile/route.ts
@@ -13,15 +13,16 @@ const unauthorizedError = { code: "unauthorized", status: 401 };
 const unknownError = { code: "unknown", status: 500 };
 
 export const GET = withApiAuthRequired(
-  async (): Promise<NextResponse<Profile | ErrorResponse>> => {
+  async (req): Promise<NextResponse<Profile | ErrorResponse>> => {
+    const res = new NextResponse();
     let accessToken: string | undefined;
 
     try {
-      const result = await getAccessToken();
+      const result = await getAccessToken(req, res);
       accessToken = result.accessToken;
 
       if (!accessToken) {
-        throw new Error(JSON.stringify(unauthorizedError));
+        throw new Error();
       }
     } catch {
       return NextResponse.json(unauthorizedError);

--- a/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
+++ b/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
@@ -2,16 +2,29 @@
 
 import { useUser } from "@auth0/nextjs-auth0/client";
 
+function AuthenticatedContent(): JSX.Element {
+  return <a href="/api/auth/logout">Logout</a>;
+}
+
+function UnauthenticatedContent(): JSX.Element {
+  return (
+    <>
+      <a href="/api/auth/login">Login</a>
+      &nbsp;or&nbsp;
+      <a href="/api/auth/signup">Sign up</a>
+    </>
+  );
+}
+
 function AuthBar(): JSX.Element {
   const { user, isLoading } = useUser();
 
-  const label = user ? "Logout" : "Login";
-  const href = user ? "api/auth/logout" : "api/auth/login";
+  const content = user ? <AuthenticatedContent /> : <UnauthenticatedContent />;
 
   return (
     <nav>
       {isLoading ? <span>Loading...</span> : null}
-      {!isLoading ? <a href={href}>{label}</a> : null}
+      {!isLoading ? content : null}
     </nav>
   );
 }

--- a/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
+++ b/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
@@ -3,14 +3,15 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
 
 function AuthBar(): JSX.Element {
-  const { user } = useUser();
+  const { user, isLoading } = useUser();
 
   const label = user ? "Logout" : "Login";
   const href = user ? "api/auth/logout" : "api/auth/login";
 
   return (
     <nav>
-      <a href={href}>{label}</a>
+      {isLoading ? <span>Loading...</span> : null}
+      {!isLoading ? <a href={href}>{label}</a> : null}
     </nav>
   );
 }

--- a/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
+++ b/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
@@ -3,13 +3,13 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
 
 function AuthenticatedContent(): JSX.Element {
-  return <a href="/api/auth/logout">Logout</a>;
+  return <a href="/api/auth/logout">Log out</a>;
 }
 
 function UnauthenticatedContent(): JSX.Element {
   return (
     <>
-      <a href="/api/auth/login">Login</a>
+      <a href="/api/auth/login">Log in</a>
       &nbsp;or&nbsp;
       <a href="/api/auth/signup">Sign up</a>
     </>

--- a/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
+++ b/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
@@ -1,9 +1,22 @@
 "use client";
 
+import type { UserContext } from "@auth0/nextjs-auth0/client";
 import { useUser } from "@auth0/nextjs-auth0/client";
 
-function AuthenticatedContent(): JSX.Element {
-  return <a href="/api/auth/logout">Log out</a>;
+interface AuthenticatedContentProps {
+  user: UserContext["user"];
+}
+
+function AuthenticatedContent({
+  user,
+}: AuthenticatedContentProps): JSX.Element {
+  return (
+    <>
+      <span>Hi, {user?.nickname || "friend"}</span>
+      &nbsp;
+      <a href="/api/auth/logout">Log out</a>;
+    </>
+  );
 }
 
 function UnauthenticatedContent(): JSX.Element {
@@ -19,7 +32,11 @@ function UnauthenticatedContent(): JSX.Element {
 function AuthBar(): JSX.Element {
   const { user, isLoading } = useUser();
 
-  const content = user ? <AuthenticatedContent /> : <UnauthenticatedContent />;
+  const content = user ? (
+    <AuthenticatedContent user={user} />
+  ) : (
+    <UnauthenticatedContent />
+  );
 
   return (
     <nav>

--- a/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
+++ b/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useUser } from "@auth0/nextjs-auth0/client";
+
+function AuthBar(): JSX.Element {
+  const { user } = useUser();
+
+  const label = user ? "Logout" : "Login";
+  const href = user ? "api/auth/logout" : "api/auth/login";
+
+  return (
+    <nav>
+      <a href={href}>{label}</a>
+    </nav>
+  );
+}
+
+export default AuthBar;

--- a/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
+++ b/apps/rwa/app/components/AuthBar/index.tsx/index.tsx
@@ -14,7 +14,7 @@ function AuthenticatedContent({
     <>
       <span>Hi, {user?.nickname || "friend"}</span>
       &nbsp;
-      <a href="/api/auth/logout">Log out</a>;
+      <a href="/api/auth/logout">Log out</a>
     </>
   );
 }

--- a/apps/rwa/app/layout.tsx
+++ b/apps/rwa/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { PropsWithChildren } from "react";
+import { UserProvider } from "@auth0/nextjs-auth0/client";
 import NavBar from "./components/NavBar";
 import "./globals.css";
 import AppHeading from "./components/AppHeading";
 import Footer from "./components/Footer";
+import AuthBar from "./components/AuthBar/index.tsx";
 
 export default function RootLayout({
   children,
@@ -14,12 +16,16 @@ export default function RootLayout({
         <title>Regular web app - Next.js</title>
       </head>
       <body>
-        <AppHeading />
-        <NavBar />
-        {children}
-        <br />
-        <br />
-        <Footer />
+        <UserProvider>
+          <AppHeading />
+          <AuthBar />
+          <br />
+          <NavBar />
+          {children}
+          <br />
+          <br />
+          <Footer />
+        </UserProvider>
       </body>
     </html>
   );

--- a/apps/rwa/app/profile/page.tsx
+++ b/apps/rwa/app/profile/page.tsx
@@ -1,3 +1,4 @@
+import { withPageAuthRequired } from "@auth0/nextjs-auth0";
 import { getProfile } from "../api/profile/route";
 
 async function ProfilePage(): Promise<JSX.Element> {
@@ -12,4 +13,4 @@ async function ProfilePage(): Promise<JSX.Element> {
   );
 }
 
-export default ProfilePage;
+export default withPageAuthRequired(ProfilePage);

--- a/apps/rwa/app/profile/page.tsx
+++ b/apps/rwa/app/profile/page.tsx
@@ -13,4 +13,4 @@ async function ProfilePage(): Promise<JSX.Element> {
   );
 }
 
-export default withPageAuthRequired(ProfilePage);
+export default withPageAuthRequired(ProfilePage, { returnTo: "/profile" });

--- a/apps/rwa/package.json
+++ b/apps/rwa/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@auth0/nextjs-auth0": "^3.2.0",
     "next": "^13.4.19",
     "profile-service": "workspace:*",
     "react": "^18.2.0",

--- a/apps/spa/README.md
+++ b/apps/spa/README.md
@@ -33,7 +33,7 @@ First, create a `.env.local` file in the root directory with the following conte
 ```sh
 VITE_AUTH0_DOMAIN='replace with domain from Auth0 dashboard'
 VITE_AUTH0_CLIENT_ID='replace with app client id from Auth0 dashboard'
-VITE_AUTH0_AUDIENCE='replace with audience from Auth0 dashboard'
+VITE_AUTH0_AUDIENCE='replace with Profile API audience from Auth0 dashboard'
 ```
 
 Then run the dev server

--- a/apps/spa/README.md
+++ b/apps/spa/README.md
@@ -25,3 +25,19 @@ If you are developing a production application, we recommend updating the config
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Development
+
+First, create a `.env.local` file in the root directory with the following content
+
+```sh
+VITE_AUTH0_DOMAIN='replace with domain from Auth0 dashboard'
+VITE_AUTH0_CLIENT_ID='replace with app client id from Auth0 dashboard'
+VITE_AUTH0_AUDIENCE='replace with audience from Auth0 dashboard'
+```
+
+Then run the dev server
+
+```sh
+pnpm dev
+```

--- a/apps/spa/package.json
+++ b/apps/spa/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@auth0/auth0-react": "^2.2.3",
     "profile-service": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/spa/src/App.tsx
+++ b/apps/spa/src/App.tsx
@@ -28,7 +28,11 @@ function App() {
     <Auth0Provider
       domain="dev-qxah68iucyxmju34.us.auth0.com"
       clientId="6xsI9n1DyjT3FaCDomx3UoBJrBuhBWvB"
-      authorizationParams={{ redirect_uri: window.location.href }}
+      authorizationParams={{
+        redirect_uri: window.location.href,
+        audience: "http://localhost:4000",
+        scope: "read:profile",
+      }}
     >
       <RouterProvider router={router} />
     </Auth0Provider>

--- a/apps/spa/src/App.tsx
+++ b/apps/spa/src/App.tsx
@@ -1,4 +1,3 @@
-import { Auth0Provider } from "@auth0/auth0-react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import Home from "./routes/home";
 import Profile from "./routes/profile";
@@ -24,19 +23,7 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  return (
-    <Auth0Provider
-      domain="dev-qxah68iucyxmju34.us.auth0.com"
-      clientId="6xsI9n1DyjT3FaCDomx3UoBJrBuhBWvB"
-      authorizationParams={{
-        redirect_uri: window.location.href,
-        audience: "http://localhost:4000",
-        scope: "read:profile",
-      }}
-    >
-      <RouterProvider router={router} />
-    </Auth0Provider>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/apps/spa/src/App.tsx
+++ b/apps/spa/src/App.tsx
@@ -1,3 +1,4 @@
+import { Auth0Provider } from "@auth0/auth0-react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import Home from "./routes/home";
 import Profile from "./routes/profile";
@@ -23,7 +24,15 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <Auth0Provider
+      domain="dev-qxah68iucyxmju34.us.auth0.com"
+      clientId="6xsI9n1DyjT3FaCDomx3UoBJrBuhBWvB"
+      authorizationParams={{ redirect_uri: window.location.href }}
+    >
+      <RouterProvider router={router} />
+    </Auth0Provider>
+  );
 }
 
 export default App;

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { Auth0Provider } from "@auth0/auth0-react";
 import AppHeading from "./components/AppHeading";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
@@ -16,7 +17,15 @@ function AppLayout(): JSX.Element {
   }, [pathname]);
 
   return (
-    <div>
+    <Auth0Provider
+      domain="dev-qxah68iucyxmju34.us.auth0.com"
+      clientId="6xsI9n1DyjT3FaCDomx3UoBJrBuhBWvB"
+      authorizationParams={{
+        redirect_uri: window.location.href,
+        audience: "http://localhost:4000",
+        scope: "read:profile",
+      }}
+    >
       <AppHeading />
       <AuthBar />
       <br />
@@ -25,7 +34,7 @@ function AppLayout(): JSX.Element {
       <br />
       <br />
       <Footer />
-    </div>
+    </Auth0Provider>
   );
 }
 

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import { Auth0Provider } from "@auth0/auth0-react";
+import { Auth0Provider, AppState } from "@auth0/auth0-react";
 import AppHeading from "./components/AppHeading";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
@@ -16,6 +16,16 @@ function AppLayout(): JSX.Element {
     }
   }, [pathname]);
 
+  const handleAuthRedirectCallback = (appState?: AppState) => {
+    if (appState?.returnTo) {
+      navigate(appState.returnTo);
+      return;
+    }
+
+    // Removes the code and state query params
+    navigate("/home");
+  };
+
   return (
     <Auth0Provider
       domain="dev-qxah68iucyxmju34.us.auth0.com"
@@ -25,15 +35,7 @@ function AppLayout(): JSX.Element {
         audience: "http://localhost:4000",
         scope: "read:profile",
       }}
-      onRedirectCallback={(appState) => {
-        if (appState?.returnTo) {
-          navigate(appState.returnTo);
-          return;
-        }
-
-        // Removes the code and state query params
-        navigate("/home");
-      }}
+      onRedirectCallback={handleAuthRedirectCallback}
     >
       <AppHeading />
       <AuthBar />

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -33,7 +33,7 @@ function AppLayout(): JSX.Element {
       authorizationParams={{
         redirect_uri: window.location.href,
         audience: "http://localhost:4000",
-        scope: "read:profile",
+        scope: "openid profile read:profile",
       }}
       onRedirectCallback={handleAuthRedirectCallback}
     >

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -25,6 +25,15 @@ function AppLayout(): JSX.Element {
         audience: "http://localhost:4000",
         scope: "read:profile",
       }}
+      onRedirectCallback={(appState) => {
+        if (appState?.returnTo) {
+          navigate(appState.returnTo);
+          return;
+        }
+
+        // Removes the code and state query params
+        navigate("/home");
+      }}
     >
       <AppHeading />
       <AuthBar />

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -36,6 +36,7 @@ function AppLayout(): JSX.Element {
         scope: "openid profile read:all_data",
       }}
       onRedirectCallback={handleAuthRedirectCallback}
+      useRefreshTokens={true}
     >
       <AppHeading />
       <AuthBar />

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -28,11 +28,11 @@ function AppLayout(): JSX.Element {
 
   return (
     <Auth0Provider
-      domain="dev-qxah68iucyxmju34.us.auth0.com"
-      clientId="6xsI9n1DyjT3FaCDomx3UoBJrBuhBWvB"
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
       authorizationParams={{
         redirect_uri: window.location.href,
-        audience: "http://localhost:4000",
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
         scope: "openid profile read:all_data",
       }}
       onRedirectCallback={handleAuthRedirectCallback}

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -33,7 +33,7 @@ function AppLayout(): JSX.Element {
       authorizationParams={{
         redirect_uri: window.location.href,
         audience: "http://localhost:4000",
-        scope: "openid profile read:profile",
+        scope: "openid profile read:all_data",
       }}
       onRedirectCallback={handleAuthRedirectCallback}
     >

--- a/apps/spa/src/AppLayout.tsx
+++ b/apps/spa/src/AppLayout.tsx
@@ -3,6 +3,7 @@ import AppHeading from "./components/AppHeading";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
 import { useEffect } from "react";
+import AuthBar from "./components/AuthBar/index.tsx";
 
 function AppLayout(): JSX.Element {
   const navigate = useNavigate();
@@ -17,6 +18,8 @@ function AppLayout(): JSX.Element {
   return (
     <div>
       <AppHeading />
+      <AuthBar />
+      <br />
       <NavBar />
       <Outlet />
       <br />

--- a/apps/spa/src/components/AuthBar/index.tsx/index.tsx
+++ b/apps/spa/src/components/AuthBar/index.tsx/index.tsx
@@ -1,0 +1,43 @@
+import { useAuth0 } from "@auth0/auth0-react";
+
+function AuthenticatedContent(): JSX.Element {
+  const { logout } = useAuth0();
+
+  return <button onClick={() => logout()}>Log out</button>;
+}
+
+function UnauthenticatedContent(): JSX.Element {
+  const { loginWithRedirect } = useAuth0();
+
+  return (
+    <>
+      <button onClick={() => loginWithRedirect()}>Log In</button>
+      &nbsp;or&nbsp;
+      <button
+        onClick={() =>
+          loginWithRedirect({ authorizationParams: { screen_hint: "signup" } })
+        }
+      >
+        Sign up
+      </button>
+    </>
+  );
+}
+
+function AuthBar(): JSX.Element {
+  const { user, isLoading, isAuthenticated } = useAuth0();
+
+  console.log("user", user);
+  console.log("isAuthenticated", isAuthenticated);
+
+  const content = user ? <AuthenticatedContent /> : <UnauthenticatedContent />;
+
+  return (
+    <nav>
+      {isLoading ? <span>Loading...</span> : null}
+      {!isLoading ? content : null}
+    </nav>
+  );
+}
+
+export default AuthBar;

--- a/apps/spa/src/components/AuthBar/index.tsx/index.tsx
+++ b/apps/spa/src/components/AuthBar/index.tsx/index.tsx
@@ -1,16 +1,26 @@
-import { useAuth0 } from "@auth0/auth0-react";
+import { useAuth0, User } from "@auth0/auth0-react";
 
-function AuthenticatedContent(): JSX.Element {
+type AuthenticatedContentProps = {
+  user: User;
+};
+
+function AuthenticatedContent({
+  user,
+}: AuthenticatedContentProps): JSX.Element {
   const { logout } = useAuth0();
 
   return (
-    <button
-      onClick={() =>
-        logout({ logoutParams: { returnTo: window.location.href } })
-      }
-    >
-      Log out
-    </button>
+    <>
+      <span>Hi, {user.nickname || "friend"}</span>
+      &nbsp;
+      <button
+        onClick={() =>
+          logout({ logoutParams: { returnTo: window.location.href } })
+        }
+      >
+        Log out
+      </button>
+    </>
   );
 }
 
@@ -33,12 +43,13 @@ function UnauthenticatedContent(): JSX.Element {
 }
 
 function AuthBar(): JSX.Element {
-  const { user, isLoading, isAuthenticated } = useAuth0();
+  const { user, isLoading } = useAuth0();
 
-  console.log("user", user);
-  console.log("isAuthenticated", isAuthenticated);
-
-  const content = user ? <AuthenticatedContent /> : <UnauthenticatedContent />;
+  const content = user ? (
+    <AuthenticatedContent user={user} />
+  ) : (
+    <UnauthenticatedContent />
+  );
 
   return (
     <nav>

--- a/apps/spa/src/components/AuthBar/index.tsx/index.tsx
+++ b/apps/spa/src/components/AuthBar/index.tsx/index.tsx
@@ -13,13 +13,7 @@ function AuthenticatedContent({
     <>
       <span>Hi, {user.nickname || "friend"}</span>
       &nbsp;
-      <button
-        onClick={() =>
-          logout({ logoutParams: { returnTo: window.location.href } })
-        }
-      >
-        Log out
-      </button>
+      <button onClick={() => logout()}>Log out</button>
     </>
   );
 }

--- a/apps/spa/src/components/AuthBar/index.tsx/index.tsx
+++ b/apps/spa/src/components/AuthBar/index.tsx/index.tsx
@@ -3,7 +3,15 @@ import { useAuth0 } from "@auth0/auth0-react";
 function AuthenticatedContent(): JSX.Element {
   const { logout } = useAuth0();
 
-  return <button onClick={() => logout()}>Log out</button>;
+  return (
+    <button
+      onClick={() =>
+        logout({ logoutParams: { returnTo: window.location.href } })
+      }
+    >
+      Log out
+    </button>
+  );
 }
 
 function UnauthenticatedContent(): JSX.Element {

--- a/apps/spa/src/routes/profile/index.tsx
+++ b/apps/spa/src/routes/profile/index.tsx
@@ -1,3 +1,4 @@
+import { useAuth0 } from "@auth0/auth0-react";
 import { Profile, getProfile } from "profile-service";
 import { useEffect, useState } from "react";
 
@@ -6,13 +7,23 @@ function ProfileRoute(): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
 
+  const {
+    getAccessTokenSilently,
+    isLoading: isLoadingAuth,
+    isAuthenticated,
+  } = useAuth0();
+
   useEffect(() => {
+    if (isLoadingAuth || !isAuthenticated) return;
+
     const getProfile_ = async () => {
       setIsLoading(true);
       setIsError(false);
 
+      const accessToken = await getAccessTokenSilently();
+
       try {
-        const data = await getProfile();
+        const data = await getProfile({ accessToken });
 
         setProfileData(data);
       } catch (e) {
@@ -24,7 +35,7 @@ function ProfileRoute(): JSX.Element {
     };
 
     getProfile_();
-  }, []);
+  }, [isLoadingAuth, isAuthenticated]);
 
   return (
     <div>

--- a/apps/spa/src/routes/profile/index.tsx
+++ b/apps/spa/src/routes/profile/index.tsx
@@ -1,4 +1,4 @@
-import { useAuth0 } from "@auth0/auth0-react";
+import { useAuth0, withAuthenticationRequired } from "@auth0/auth0-react";
 import { Profile, getProfile } from "profile-service";
 import { useEffect, useState } from "react";
 
@@ -50,4 +50,6 @@ function ProfileRoute(): JSX.Element {
   );
 }
 
-export default ProfileRoute;
+export default withAuthenticationRequired(ProfileRoute, {
+  onRedirecting: () => <div>Loading...</div>,
+});

--- a/apps/spa/src/routes/profile/index.tsx
+++ b/apps/spa/src/routes/profile/index.tsx
@@ -20,7 +20,16 @@ function ProfileRoute(): JSX.Element {
       setIsLoading(true);
       setIsError(false);
 
-      const accessToken = await getAccessTokenSilently();
+      let accessToken: string;
+
+      try {
+        accessToken = await getAccessTokenSilently();
+      } catch {
+        // TODO: log the user out so that they can log in again with a new token
+        setIsError(true);
+        setIsLoading(false);
+        return;
+      }
 
       try {
         const data = await getProfile({ accessToken });

--- a/packages/profile-service/src/index.ts
+++ b/packages/profile-service/src/index.ts
@@ -5,6 +5,26 @@ export type Profile = {
   address: string;
 };
 
+const makeErrorPayload = (status: number) => {
+  switch (status) {
+    case 401:
+      return {
+        code: "profile-service-unauthorized",
+        status,
+      };
+    case 403:
+      return {
+        code: "profile-service-forbidden",
+        status,
+      };
+    default:
+      return {
+        code: "profile-service-unknown",
+        status,
+      };
+  }
+};
+
 type Params = {
   accessToken: string;
 };
@@ -15,13 +35,13 @@ export const getProfile = async ({ accessToken }: Params) => {
   });
 
   if (!response.ok || response.status >= 400) {
-    throw new Error(`Error getting profile - http status: ${response.status}`);
+    throw new Error(JSON.stringify(makeErrorPayload(response.status)));
   }
 
   try {
     const data = await response.json();
     return data as Profile;
   } catch {
-    throw new Error("Error getting profile - json");
+    throw new Error(JSON.stringify(makeErrorPayload(500)));
   }
 };

--- a/packages/profile-service/src/index.ts
+++ b/packages/profile-service/src/index.ts
@@ -5,11 +5,17 @@ export type Profile = {
   address: string;
 };
 
-export const getProfile = async () => {
-  const response = await fetch(`${baseUrl}/profile`);
+type Params = {
+  accessToken: string;
+};
+
+export const getProfile = async ({ accessToken }: Params) => {
+  const response = await fetch(`${baseUrl}/profile`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
 
   if (!response.ok || response.status >= 400) {
-    throw new Error("Error getting profile - http");
+    throw new Error(`Error getting profile - http status: ${response.status}`);
   }
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.18.2
+      express-oauth2-jwt-bearer:
+        specifier: ^1.6.0
+        version: 1.6.0
     devDependencies:
       '@tsconfig/recommended':
         specifier: ^1.0.3
@@ -2740,6 +2743,13 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
     dev: true
+
+  /express-oauth2-jwt-bearer@1.6.0:
+    resolution: {integrity: sha512-HXnez7vocYlOqlfF3ozPcf/WE3zxT7zfUNfeg5FHJnvNwhBYlNXiPOvuCtBalis8xcigvwtInzEKhBuH87+9ug==}
+    engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.12.0 || ^20.2.0}
+    dependencies:
+      jose: 4.15.4
+    dev: false
 
   /express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
 
   apps/rwa:
     dependencies:
+      '@auth0/nextjs-auth0':
+        specifier: ^3.2.0
+        version: 3.2.0(next@13.4.19)
       next:
         specifier: ^13.4.19
         version: 13.4.19(react-dom@18.2.0)(react@18.2.0)
@@ -173,6 +176,26 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
+
+  /@auth0/nextjs-auth0@3.2.0(next@13.4.19):
+    resolution: {integrity: sha512-8vdoqEF+RfAAdG9O2r8QbRs95LraDYhDGlfTzQdGg5CYTBGUWO34EZOB9bZr0SgqnqaO9Qa4lgcrffsYPcvywg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      next: '>=10'
+    dependencies:
+      '@panva/hkdf': 1.1.1
+      cookie: 0.5.0
+      debug: 4.3.4
+      joi: 17.11.0
+      jose: 4.15.4
+      next: 13.4.19(react-dom@18.2.0)(react@18.2.0)
+      oauth4webapi: 2.3.0
+      openid-client: 5.6.1
+      tslib: 2.5.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@babel/code-frame@7.22.10:
     resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
@@ -627,6 +650,16 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@hapi/hoek@9.3.0:
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+    dev: false
+
+  /@hapi/topo@5.1.0:
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+    dev: false
+
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
     engines: {node: '>=10.10.0'}
@@ -815,6 +848,10 @@ packages:
       fastq: 1.15.0
     dev: true
 
+  /@panva/hkdf@1.1.1:
+    resolution: {integrity: sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==}
+    dev: false
+
   /@pkgr/utils@2.4.0:
     resolution: {integrity: sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -835,6 +872,20 @@ packages:
   /@rushstack/eslint-patch@1.3.3:
     resolution: {integrity: sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==}
     dev: true
+
+  /@sideway/address@4.1.4:
+    resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+    dev: false
+
+  /@sideway/formula@3.0.1:
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+    dev: false
+
+  /@sideway/pinpoint@2.0.0:
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
+    dev: false
 
   /@swc/core-darwin-arm64@1.3.95:
     resolution: {integrity: sha512-VAuBAP3MNetO/yBIBzvorUXq7lUBwhfpJxYViSxyluMwtoQDhE/XWN598TWMwMl1ZuImb56d7eUsuFdjgY7pJw==}
@@ -1924,7 +1975,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /deep-equal@2.2.1:
     resolution: {integrity: sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==}
@@ -3389,6 +3439,20 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
+  /joi@17.11.0:
+    resolution: {integrity: sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.4
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
+    dev: false
+
+  /jose@4.15.4:
+    resolution: {integrity: sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3503,7 +3567,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -3589,7 +3652,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3704,9 +3766,18 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /oauth4webapi@2.3.0:
+    resolution: {integrity: sha512-JGkb5doGrwzVDuHwgrR4nHJayzN4h59VCed6EW8Tql6iHDfZIabCJvg6wtbn5q6pyB2hZruI3b77Nudvq7NmvA==}
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  /object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -3777,6 +3848,11 @@ packages:
       es-abstract: 1.21.2
     dev: true
 
+  /oidc-token-hash@5.0.3:
+    resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
+    engines: {node: ^10.13.0 || >=12.0.0}
+    dev: false
+
   /on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3813,6 +3889,15 @@ packages:
       is-inside-container: 1.0.0
       is-wsl: 2.2.0
     dev: true
+
+  /openid-client@5.6.1:
+    resolution: {integrity: sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==}
+    dependencies:
+      jose: 4.15.4
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.0.3
+    dev: false
 
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -4782,6 +4867,10 @@ packages:
       punycode: 2.3.0
     dev: true
 
+  /url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+    dev: false
+
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -4923,7 +5012,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -2105,6 +2108,11 @@ packages:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
     dev: true
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
 
   apps/spa:
     dependencies:
+      '@auth0/auth0-react':
+        specifier: ^2.2.3
+        version: 2.2.3(react-dom@18.2.0)(react@18.2.0)
       profile-service:
         specifier: workspace:*
         version: link:../../packages/profile-service
@@ -179,6 +182,21 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
+
+  /@auth0/auth0-react@2.2.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-3B0KA/ky1yA6iQK8045N8U0ZBkmDB3ElCSwJuxNbAoKmZBc4+DjzZhWRxYsgb9PrfHC14Lr2h4950A3PEFDULA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17 || ^18
+      react-dom: ^16.11.0 || ^17 || ^18
+    dependencies:
+      '@auth0/auth0-spa-js': 2.1.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@auth0/auth0-spa-js@2.1.2:
+    resolution: {integrity: sha512-xdA65Z/U7++Y7L9Uwh8Q8OVOs6qgFz+fb7GAzHFjpr1icO37B//xdzLXm7ZRgA19RWrsNe1nme3h896igJSvvw==}
+    dev: false
 
   /@auth0/nextjs-auth0@3.2.0(next@13.4.19):
     resolution: {integrity: sha512-8vdoqEF+RfAAdG9O2r8QbRs95LraDYhDGlfTzQdGg5CYTBGUWO34EZOB9bZr0SgqnqaO9Qa4lgcrffsYPcvywg==}


### PR DESCRIPTION
# Changes
- Setup Auth0
  - API for the profile api. Requires scope `read:all_data` to read profile data
  - Applications for the RWA and SPA
  - Enabled refreshing access tokens via the `offline_access` scope and the relevant tenant & application settings
- Secured the RWA
  - Profile page and api route
  - Added audience and scope for accessing the profile API
- Secured the SPA
  - Profile page
  - Configured the Auth0 provider with the required audience and scope for the profile API 
- Secured profile API
  - Used `express-oauth2-jwt-bearer` to check the JWT and scopes 
  